### PR TITLE
[#9] 비동기 이벤트 처리

### DIFF
--- a/profile-search/src/main/java/com/task/ProfileApplication.java
+++ b/profile-search/src/main/java/com/task/ProfileApplication.java
@@ -4,7 +4,9 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 
+@EnableAsync
 @SpringBootApplication
 @EnableJpaAuditing
 @EnableCaching

--- a/profile-search/src/main/java/com/task/config/AsyncConfig.java
+++ b/profile-search/src/main/java/com/task/config/AsyncConfig.java
@@ -1,0 +1,45 @@
+package com.task.config;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.concurrent.Executor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@Slf4j
+public class AsyncConfig implements AsyncConfigurer {
+
+    @Bean("TaskExecutor")
+    @Override
+    public Executor getAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        int cpuCoreCount = Runtime.getRuntime().availableProcessors();
+        executor.setCorePoolSize(cpuCoreCount);
+        executor.setMaxPoolSize(cpuCoreCount * 2);
+        executor.setQueueCapacity(10);
+        executor.setKeepAliveSeconds(60);
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(60);
+        executor.setThreadNamePrefix("Task-");
+        executor.initialize();
+        return executor;
+    }
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return new CustomAsyncExceptionHandler();
+    }
+
+    private class CustomAsyncExceptionHandler implements AsyncUncaughtExceptionHandler {
+        @Override
+        public void handleUncaughtException(Throwable ex, Method method, Object... params) {
+            log.error("Failed to execute {}", ex.getMessage());
+            Arrays.asList(params).forEach(param -> log.error("parameter value = {}", param));
+        }
+    }
+}

--- a/profile-search/src/main/java/com/task/controller/ProfileController.java
+++ b/profile-search/src/main/java/com/task/controller/ProfileController.java
@@ -28,7 +28,7 @@ public class ProfileController {
     // 상세 조회
     @GetMapping("/{id}")
     public ResponseEntity<ApiResponse<ProfileResponse>> getById(@PathVariable("id") Long id){
-        ProfileResponse response = profileApplicationService.getById(id);
+        ProfileResponse response = profileApplicationService.getProfileAndSendEvent(id);
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.ok(response));
     }
 

--- a/profile-search/src/main/java/com/task/infrastructure/profile_stat/ProfileViewStatEntity.java
+++ b/profile-search/src/main/java/com/task/infrastructure/profile_stat/ProfileViewStatEntity.java
@@ -33,12 +33,12 @@ public class ProfileViewStatEntity {
     @JoinColumn(name = "profile_id")
     private ProfileEntity profileEntity;
 
-    @CreatedDate
     @Column(name = "created_at")
     private LocalDateTime createdAt;
 
-    public ProfileViewStatEntity(ProfileEntity profileEntity) {
+    public ProfileViewStatEntity(ProfileEntity profileEntity,  LocalDateTime timeStamp) {
         this.profileEntity = profileEntity;
+        this.createdAt = timeStamp;
     }
 
     @Override

--- a/profile-search/src/main/java/com/task/service/ProfileApplicationService.java
+++ b/profile-search/src/main/java/com/task/service/ProfileApplicationService.java
@@ -1,15 +1,13 @@
 package com.task.service;
 
-import com.task.ApiException;
-import com.task.ErrorType;
 import com.task.PageResult;
 import com.task.controller.response.ProfileResponse;
-import com.task.infrastructure.profile.ProfileEntity;
-import com.task.infrastructure.profile_stat.ProfileViewStatEntity;
 import com.task.service.profile.ProfileQueryService;
-import com.task.service.profile_stat.ProfileViewStatCommandService;
+import com.task.service.profile.event.ProfileQueryEvent;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
@@ -19,26 +17,16 @@ import org.springframework.stereotype.Service;
 public class ProfileApplicationService {
 
     private final ProfileQueryService profileQueryService;
-    private final ProfileViewStatCommandService profileViewStatCommandService;
+    private final ApplicationEventPublisher eventPublisher;
 
-    @Cacheable(value = "profile", key = "#id")
-    public ProfileResponse getById(Long id) {
-        ProfileResponse response = profileQueryService.getById(id);
-        ProfileViewStatEntity viewStatEntity = new ProfileViewStatEntity(new ProfileEntity(
-            response.getId(),
-            response.getName()));
-        profileViewStatCommandService.save(viewStatEntity); // 이벤트로 빼기
+    public ProfileResponse getProfileAndSendEvent(Long id) {
+        ProfileResponse response = profileQueryService.getById(id);  // 캐시에서 조회
+        eventPublisher.publishEvent(new ProfileQueryEvent(id, response.getName(), LocalDateTime.now())); // 향후 kafka로 변경
         return response;
     }
 
-    @Cacheable(cacheNames = "profiles", value = "profiles", key = "'page_' + #pageable.getOffset() + "
-        + "'_size_' + #pageable.getPageSize() + '_sort_' + #pageable.sort.toString()")
     public PageResult<ProfileResponse> getAllByCondition(Pageable pageable) {
         return profileQueryService.getAllByCondition(pageable);
     }
 
-    @Cacheable(key = "hello")
-    public String test() {
-        return "hello";
-    }
 }

--- a/profile-search/src/main/java/com/task/service/profile/ProfileQueryServiceImpl.java
+++ b/profile-search/src/main/java/com/task/service/profile/ProfileQueryServiceImpl.java
@@ -7,6 +7,7 @@ import com.task.controller.response.ProfileResponse;
 import com.task.infrastructure.profile.ProfileEntity;
 import com.task.infrastructure.profile.ProfileRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -18,6 +19,7 @@ public class ProfileQueryServiceImpl implements ProfileQueryService {
 
     private final ProfileRepository profileRepository;
 
+    @Cacheable(value = "profile", key = "#id")
     @Override
     public ProfileResponse getById(Long id) {
         return profileRepository.searchById(id)
@@ -26,6 +28,9 @@ public class ProfileQueryServiceImpl implements ProfileQueryService {
             , HttpStatus.NOT_FOUND));
     }
 
+    @Cacheable(cacheNames = "profiles", value = "profiles", key =
+        "'page_' + #pageable.getOffset() + "
+            + "'_size_' + #pageable.getPageSize() + '_sort_' + #pageable.sort.toString()")
     @Override
     public PageResult<ProfileResponse> getAllByCondition(Pageable pageable) {
         return profileRepository.getAllByCondition(pageable);

--- a/profile-search/src/main/java/com/task/service/profile/event/ProfileQueryEvent.java
+++ b/profile-search/src/main/java/com/task/service/profile/event/ProfileQueryEvent.java
@@ -1,0 +1,11 @@
+package com.task.service.profile.event;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+
+public record ProfileQueryEvent(Long profileId, String name, LocalDateTime timeStamp) { }

--- a/profile-search/src/main/java/com/task/service/profile/event/ProfileQueryEventHandler.java
+++ b/profile-search/src/main/java/com/task/service/profile/event/ProfileQueryEventHandler.java
@@ -1,0 +1,27 @@
+package com.task.service.profile.event;
+
+import com.task.infrastructure.profile.ProfileEntity;
+import com.task.infrastructure.profile_stat.ProfileViewStatEntity;
+import com.task.service.profile_stat.ProfileViewStatCommandService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ProfileQueryEventHandler {
+
+    private final ProfileViewStatCommandService profileViewStatCommandService;
+
+    @Async
+    @EventListener
+    public void handleProfileQueryEvent(ProfileQueryEvent event) throws InterruptedException {
+        log.info("[ProfileQueryEventHandler] handleEvent : {}", event);
+        ProfileEntity profile = new ProfileEntity(event.profileId(), event.name());
+        ProfileViewStatEntity profileViewStat = new ProfileViewStatEntity(profile, event.timeStamp());
+        profileViewStatCommandService.save(profileViewStat);
+    }
+}


### PR DESCRIPTION
### 작업 내용 #9 
- ApplicationEventPublisher을 통한 비동기 이벤트 처리

 ### ApplicationEventPublisher 사용이유
조회수 데이터는 중요도가 낮은 비즈니스 로직이기 때문에, 유실되더라도 시스템 전체에 지장이 없다고 판단했습니다. 조회수는 실시간으로 정확할 필요는 없으며, 어느 정도의 오차는 허용 가능하므로 안정성이 완벽하게 보장될 필요가 없습니다.
조회수 증가와 같은 가벼운 로그를 저장하는 작업에는 Redis나 Kafka를 사용하지 않아도 충분한 성능을 낼 수 있습니다. 더해서 비용적인 측면에서도 매니지먼트 서비스를 사용하지 않기때문에 비용측면에서도 효율적이라고 생각합니다.
 
ApplicationEventPublisher를 사용하면 필요 시에 다른 메시징 시스템(kafka, rabbitmq 등)으로 쉽게 변경할 수 있습니다. 

Redis로 배치처리하면 즉각적으로 반영 못합니다. 그러나 이벤트를 통해 비동기 처리를 즉각 반영도 가능합니다.
지금은 Redis캐시로 조회수를 실시간으로 업데이트한 개수를 보여주지는 않지만 ttl이 끝나면 반영되기때문에 추후 실시간 반영이 필요한 경우에도 유용하다고 생각했습니다.
