### PR TITLE
[#10] 고가용성 대비 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,12 @@ subprojects {
 		mavenCentral()
 	}
 
+	dependencyManagement {
+		imports {
+			mavenBom "org.springframework.cloud:spring-cloud-dependencies:2023.0.1"
+		}
+	}
+
 	dependencies {
 		implementation 'org.springframework.boot:spring-boot-starter-web'
 		compileOnly 'org.projectlombok:lombok'

--- a/profile-search/build.gradle
+++ b/profile-search/build.gradle
@@ -14,6 +14,8 @@ dependencies {
 
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    // resilience4j
+    implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j'
 }
 
 clean {

--- a/profile-search/src/main/java/com/task/infrastructure/profile/ProfileRepository.java
+++ b/profile-search/src/main/java/com/task/infrastructure/profile/ProfileRepository.java
@@ -1,7 +1,8 @@
 package com.task.infrastructure.profile;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
-
+@Repository
 public interface ProfileRepository extends JpaRepository<ProfileEntity, Long>, ProfileRepositoryCustom {
 }

--- a/profile-search/src/main/java/com/task/infrastructure/profile/ProfileRepositoryCustomImpl.java
+++ b/profile-search/src/main/java/com/task/infrastructure/profile/ProfileRepositoryCustomImpl.java
@@ -9,6 +9,8 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.task.ApiException;
+import com.task.ErrorType;
 import com.task.PageResult;
 import com.task.controller.response.ProfileResponse;
 import com.task.util.DateUtils;
@@ -18,6 +20,7 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -46,6 +49,7 @@ public class ProfileRepositoryCustomImpl implements ProfileRepositoryCustom {
             .from(profileEntity)
             .where(profileEntity.id.eq(id))
             .fetchOne();
+
         return Optional.ofNullable(response);
     }
 

--- a/profile-search/src/main/java/com/task/service/profile/ProfileQueryServiceImpl.java
+++ b/profile-search/src/main/java/com/task/service/profile/ProfileQueryServiceImpl.java
@@ -6,7 +6,11 @@ import com.task.PageResult;
 import com.task.controller.response.ProfileResponse;
 import com.task.infrastructure.profile.ProfileEntity;
 import com.task.infrastructure.profile.ProfileRepository;
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
@@ -14,11 +18,15 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class ProfileQueryServiceImpl implements ProfileQueryService {
 
     private final ProfileRepository profileRepository;
 
+
+    // 서킷 적용하기
+    @CircuitBreaker(name = "ProfileGetById", fallbackMethod = "getByIdFallBack")
     @Cacheable(value = "profile", key = "#id")
     @Override
     public ProfileResponse getById(Long id) {
@@ -27,6 +35,17 @@ public class ProfileQueryServiceImpl implements ProfileQueryService {
                 new ApiException("profiles-search에서 ID "+ id + " 찾을 수 없습니다", ErrorType.NO_RESOURCE
             , HttpStatus.NOT_FOUND));
     }
+
+    // 로컬 캐시에 담기 - 서비스마다 로컬 캐시에 담긴 데이터가 다를 수 있다는 점을 주의해야 한다.
+    // 그런데 이는 db에 영향을 주어 전체적인 서비스에 영향을 줄 수 있기때문에 redis cluster나 sentinal로 고가용성을 해두기 때문에 이 시간동안 버티는 용도
+    public ProfileResponse getByIdFallBack(Long id, Throwable throwable){
+        log.warn("[ProfileQueryServiceImpl] Circuit Breaker is open! Fallback to DB search.");
+        return profileRepository.searchById(id)
+            .orElseThrow(()->
+                new ApiException("profiles-search에서 ID "+ id + " 찾을 수 없습니다", ErrorType.NO_RESOURCE
+                    , HttpStatus.NOT_FOUND));
+    }
+
 
     @Cacheable(cacheNames = "profiles", value = "profiles", key =
         "'page_' + #pageable.getOffset() + "


### PR DESCRIPTION
### 작업 사항 #10 
- CircuitBreaker패턴 resilience4j 적용


### 시나리오
Redis를 캐시저장소로 사용하는데 Redis가 문제가 생긴경우 db에 직접 select하는것으로 정했습니다.
더 나아가 local cache를 2차적으로 사용하는것보다 바로 db에 한 이유는 redis의 복구는 빠를거라 생각했고 주로 prod환경에서는
read, write를 나누기때문입니다. 
더해서 Redis의 마스터/슬레이브 과정으로 변경되는 시간동안만 부하를 db에 직접 버티면 괜찮지 않을가 생각했습니다.
그리고 아마 캐시 저장소 문제는 캐시 저장소 용량이 가득찬 경우일거 같기 때문입니다. 
